### PR TITLE
fix: resolve race condition causing empty recent files list on load

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -63,3 +63,4 @@
 - 2026-01-04 10:56:03 UTC: Created issue #30 for automating tldraw dependency updates when new 'next' versions are released
 - 2026-01-04 12:40:47 UTC: Implemented issue #30 - added .github/workflows/update-tldraw.yml for automated tldraw dependency updates
 - 2026-01-04 13:18:43 UTC: Updated update-tldraw.yml to support repository_dispatch from tldraw repo, added auto-merge; changed release.yml to publish immediately instead of draft
+- 2026-01-05 18:31:43 UTC: fixed race condition in home.tsx - recent files not showing on initial load (issue #33)

--- a/src/renderer/src/pages/home.tsx
+++ b/src/renderer/src/pages/home.tsx
@@ -4,15 +4,18 @@ import { TitleBar } from '@renderer/components/Titlebar'
 import { TldrawLogo } from '@renderer/components/tldraw-logo'
 import { useRecentFiles } from '@renderer/hooks/useRecentFiles'
 import classNames from 'classnames'
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useState } from 'react'
 
 export function Component() {
-	useEffect(() => {
+	// useLayoutEffect ensures all child component effects (like useRecentFiles listener)
+	// are registered before we send home-loaded, preventing a race condition where
+	// the home-info-ready response arrives before listeners are attached
+	useLayoutEffect(() => {
 		// When the api knows we're loaded, it will send a 'home-info-ready' event
 		const cleanup = window.api.onMainEvent('home-info-ready', () => {
 			window.api.sendRendererEventToMain('home-ready-to-show', {})
 		})
-		// 1. Tell the main process that we're ready to load the home page
+		// Tell the main process that we're ready to load the home page
 		window.api.sendRendererEventToMain('home-loaded', {})
 		return () => {
 			cleanup()


### PR DESCRIPTION
Fixes a race condition where the recent files list appeared empty on app launch until the user performed an action like saving or opening a file.

The root cause was a timing issue between React effect hooks and IPC events. The `home.tsx` component was sending the `home-loaded` event via `useEffect`, which could fire before the `useRecentFiles` hook's `useLayoutEffect` had registered its listener for `home-info-ready`. Since Electron's IPC doesn't queue messages for late listeners, the initial data was missed.

The fix changes `useEffect` to `useLayoutEffect` in `home.tsx`, ensuring all child component effects (including the recent files listener) are registered before sending `home-loaded`.

Fixes #33

### Change type

- [x] `bugfix`

### Test plan

1. Open some `.tldr` files to populate the recent files list
2. Close the app completely  
3. Launch the app fresh
4. Verify the recent files list appears immediately on the home screen

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where the recent files list was empty on initial app load